### PR TITLE
Enable auto-merge and tweak Azurerm naming module logic

### DIFF
--- a/terraform-module.json
+++ b/terraform-module.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Upgrade all terraform modules with minor and patch upgrades",
-  "groupName": "Terraform module minor and patch upgrades",
-  "groupSlug": "terraform-module-minor-patch",
   "postUpgradeTasks": {
     "commands": [
       "terraform-docs markdown {{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
@@ -30,6 +28,11 @@
         ],
         "executionMode": "update"
       }
+    },
+    {
+      "matchDatasources": ["terraform-module"],
+      "groupName": "Terraform module minor and patch upgrades",
+      "groupSlug": "terraform-module-minor-patch"
     }
   ]
 }

--- a/terraform-module.json
+++ b/terraform-module.json
@@ -5,9 +5,7 @@
     "commands": [
       "terraform-docs markdown {{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
     ],
-    "fileFilters": [
-      "**/README.md"
-    ],
+    "fileFilters": ["**/*.tf", "**/*.tfvars", "**/*.tftest"],
     "executionMode": "update"
   },
   "packageRules": [
@@ -23,9 +21,7 @@
         "commands": [
           "terraform-docs markdown {{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
         ],
-        "fileFilters": [
-          "**/README.md"
-        ],
+        "fileFilters": ["**/*.tf", "**/*.tfvars", "**/*.tftest"],
         "executionMode": "update"
       }
     },

--- a/terraform-module.json
+++ b/terraform-module.json
@@ -1,15 +1,35 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "description": "Upgrade all terraform modules with minor and patch upgrades",
-    "groupName": "Terraform module minor and patch upgrades",
-    "groupSlug": "terraform-module-minor-patch",
-    "postUpgradeTasks": {
-      "commands": [
-        "terraform-docs markdown {{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Upgrade all terraform modules with minor and patch upgrades",
+  "groupName": "Terraform module minor and patch upgrades",
+  "groupSlug": "terraform-module-minor-patch",
+  "postUpgradeTasks": {
+    "commands": [
+      "terraform-docs markdown {{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
+    ],
+    "fileFilters": [
+      "**/README.md"
+    ],
+    "executionMode": "update"
+  },
+  "packageRules": [
+    {
+      "matchDatasources": ["terraform-module"],
+      "matchPackageNames": ["Azure/naming/azurerm"],
+      "registryUrls": [
+        "https://registry.terraform.io"
       ],
-      "fileFilters": [
-        "**/README.md"
-      ],
-      "executionMode": "update"
+      "groupName": "Azure/naming/azurerm upgrades",
+      "automerge": true,
+      "postUpgradeTasks": {
+        "commands": [
+          "terraform-docs markdown {{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
+        ],
+        "fileFilters": [
+          "**/README.md"
+        ],
+        "executionMode": "update"
+      }
     }
-  }
+  ]
+}

--- a/terraform-provider.json
+++ b/terraform-provider.json
@@ -16,9 +16,7 @@
     "commands": [
       "terraform-docs markdown {{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
     ],
-    "fileFilters": [
-      "**/README.md"
-    ],
+    "fileFilters": ["**/*.tf", "**/*.tfvars", "**/*.tftest"],
     "executionMode": "update"
   }
 }

--- a/terraform-provider.json
+++ b/terraform-provider.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Upgrade all terraform providers with minor and patch upgrades",
-  "matchDatasources": ["terraform-provider"],
+  "packageRules": [
+    {
+      "matchDatasources": ["terraform-provider"]
+    }
+  ],
   "groupName": "Terraform provider minor and patch upgrades",
   "groupSlug": "terraform-provider-minor-patch",
   "postUpgradeTasks": {

--- a/terraform-provider.json
+++ b/terraform-provider.json
@@ -1,15 +1,20 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "description": "Upgrade all terraform providers with minor and patch upgrades",
-    "groupName": "Terraform provider minor and patch upgrades",
-    "groupSlug": "terraform-provider-minor-patch",
-    "postUpgradeTasks": {
-      "commands": [
-        "terraform-docs markdown {{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
-      ],
-      "fileFilters": [
-        "**/README.md"
-      ],
-      "executionMode": "update"
-    }
-  }
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Upgrade all terraform providers with minor and patch upgrades",
+  "matchDatasources": ["terraform-provider"],
+  "groupName": "Terraform provider minor and patch upgrades",
+  "groupSlug": "terraform-provider-minor-patch",
+  "postUpgradeTasks": {
+    "commands": [
+      "terraform-docs markdown {{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
+    ],
+    "fileFilters": [
+      "**/README.md"
+    ],
+    "executionMode": "update"
+  },
+  "extends": [
+    ":automergePatch",
+    ":automergeMinor"
+  ]
+}

--- a/terraform-provider.json
+++ b/terraform-provider.json
@@ -3,11 +3,15 @@
   "description": "Upgrade all terraform providers with minor and patch upgrades",
   "packageRules": [
     {
-      "matchDatasources": ["terraform-provider"]
+      "matchDatasources": ["terraform-provider"],
+      "groupName": "Terraform provider minor and patch upgrades",
+      "groupSlug": "terraform-provider-minor-patch",
+      "extends": [
+        ":automergePatch",
+        ":automergeMinor"
+      ]
     }
   ],
-  "groupName": "Terraform provider minor and patch upgrades",
-  "groupSlug": "terraform-provider-minor-patch",
   "postUpgradeTasks": {
     "commands": [
       "terraform-docs markdown {{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
@@ -16,9 +20,5 @@
       "**/README.md"
     ],
     "executionMode": "update"
-  },
-  "extends": [
-    ":automergePatch",
-    ":automergeMinor"
-  ]
+  }
 }

--- a/tests/SystemTests.cs
+++ b/tests/SystemTests.cs
@@ -782,16 +782,6 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
 
         await testContext.AssertPullRequests(
             """
-            - Title: Update Terraform provider minor and patch upgrades
-              Labels:
-                - renovate
-              PackageUpdatesInfos:
-                - Package: azuread
-                  Type: required_provider
-                  Update: minor
-                - Package: azurerm
-                  Type: required_provider
-                  Update: minor
             - Title: Update Terraform provider minor and patch upgrades (major)
               Labels:
                 - renovate
@@ -802,6 +792,17 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
                 - Package: azurerm
                   Type: required_provider
                   Update: major
+            - Title: Update Terraform provider minor and patch upgrades (minor)
+              Labels:
+                - renovate
+              PackageUpdatesInfos:
+                - Package: azuread
+                  Type: required_provider
+                  Update: minor
+                - Package: azurerm
+                  Type: required_provider
+                  Update: minor
+              IsAutoMergeEnabled: true
             """);
     }
 }


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
Added auto-merge to Terraform providers patches and minor updates. Created a package rule to properly handle the azurerm naming module.

## Breaking changes
None

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [X] Updated the documentation of the project to reflect the changes
- [X] Added new tests that cover the code changes