### PR TITLE
IDP-3359 Adopt github `github-actions[bot]` committer

### DIFF
--- a/default.json
+++ b/default.json
@@ -29,6 +29,7 @@
   "branchConcurrentLimit": 0,
   "dependencyDashboard": false,
   "gitAuthor": "github-actions[bot] <github-actions[bot]@users.noreply.github.com>",
+
   "configMigration": true,
   "minimumReleaseAge": "3 days",
   "azure-pipelines": {

--- a/default.json
+++ b/default.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Workleap's default preset",
-  "gitAuthor": "github-actions[bot] <github-actions[bot]@users.noreply.github.com>",
   "labels": [
     "renovate"
   ],
@@ -29,7 +28,7 @@
   "prConcurrentLimit": 0,
   "branchConcurrentLimit": 0,
   "dependencyDashboard": false,
-  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+  "gitAuthor": "github-actions[bot] <github-actions[bot]@users.noreply.github.com>",
   "configMigration": true,
   "minimumReleaseAge": "3 days",
   "azure-pipelines": {

--- a/default.json
+++ b/default.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Workleap's default preset",
+  "gitAuthor": "github-actions[bot] <github-actions[bot]@users.noreply.github.com>",
   "labels": [
     "renovate"
   ],

--- a/default.json
+++ b/default.json
@@ -28,8 +28,7 @@
   "prConcurrentLimit": 0,
   "branchConcurrentLimit": 0,
   "dependencyDashboard": false,
-  "gitAuthor": "github-actions[bot] <github-actions[bot]@users.noreply.github.com>",
-
+  "gitAuthor": "github-actions[bot] <github-actions[bot]@users.noreply.github.com>",
   "configMigration": true,
   "minimumReleaseAge": "3 days",
   "azure-pipelines": {


### PR DESCRIPTION


<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
For some reason, this is not well documented on GitHub, but it seems that `github-actions[bot] <github-actions[bot]@users.noreply.github.com>` is the recommended commiter to use on GitHub when committing from within an actions workflow.

We already use this committer to commit automated documentation updates in our terraform repos and when that committer commits over the default `Renovate Bot <bot@renovateapp.com>` to update the docs to reflect a formatting change, renovate refuses to operate on the branch anymore.

We must use a consistent committer for all of our bot workflows so that they work in harmony.

## Breaking changes
<!-- What breaking changes were added (if any) and how are they addressed? -->

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes