### PR TITLE
IDP-3359 Add ./ to terraform-docs packageFileDir

### DIFF
--- a/terraform-module.json
+++ b/terraform-module.json
@@ -19,7 +19,7 @@
       "automerge": true,
       "postUpgradeTasks": {
         "commands": [
-          "terraform-docs markdown {{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
+          "terraform-docs markdown ./{{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
         ],
         "fileFilters": ["**/*.tf", "**/*.tfvars", "**/*.tftest"],
         "executionMode": "update"

--- a/terraform-provider.json
+++ b/terraform-provider.json
@@ -14,7 +14,7 @@
   ],
   "postUpgradeTasks": {
     "commands": [
-      "terraform-docs markdown {{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
+      "terraform-docs markdown ./{{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
     ],
     "fileFilters": ["**/*.tf", "**/*.tfvars", "**/*.tftest"],
     "executionMode": "update"


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes

`packageFileDir` resolves to a blank string when the terraform files are at the root of the repo like they are in our terraform module repos, causing the `terraform-docs` invocation to fail as the path parameter is needed. We'd want it to return `.` but there's no way to specify a default value in renovate's templating so this should work fine as a workaround

I confirmed that `packageFileDir` is a path relative to the root of the repo by looking at some previous runs on ADO with debug logging:

```
DEBUG: Executing command (repository=<redacted>, branch=renovate/core-terraform-provider-minor-patch)
       "dep": "azurerm",
       "command": "terraform-docs markdown path/is/redacted --hide resources,data-sources --output-file README.md --output-mode replace"
```       
## Breaking changes
<!-- What breaking changes were added (if any) and how are they addressed? -->

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes