### PR TITLE
chore(deps): disable upgrades for FluentAssertion, due to recent licensing changes

### DIFF
--- a/default.json
+++ b/default.json
@@ -151,6 +151,16 @@
         ":pinDependencies",
         ":pinDevDependencies"
       ]
+    },
+    {
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "FluentAssertions"
+      ],
+      "allowedVersions": "< 8.0.0",
+      "description": "Licensing changed from V8 and onward to be commercial. See https://fluentassertions.com/releases/#800 for context."
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Description of changes
Disable package upgrades for `FluentAssertions`, for which licensing changed to commercial from v8 and forward ([ref](https://fluentassertions.com/releases/#license-change))