### PR TITLE
[IDP-3371] chore(deps): disable upgrades for packages with commercial licenses

### DIFF
--- a/default.json
+++ b/default.json
@@ -151,6 +151,16 @@
         ":pinDependencies",
         ":pinDevDependencies"
       ]
+    },
+    {
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "FluentAssertions"
+      ],
+      "allowedVersions": "< 8.0.0",
+      "description": "Licensing changed from V8 and onward to be commercial. See https://fluentassertions.com/releases/#800 for context."
     }
   ],
   "vulnerabilityAlerts": {

--- a/default.json
+++ b/default.json
@@ -161,6 +161,17 @@
       ],
       "allowedVersions": "< 8.0.0",
       "description": "Licensing changed from V8 and onward to be commercial. See https://fluentassertions.com/releases/#800 for context."
+    },
+    {
+      "groupName": "prism monorepo",
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchSourceUrls": [
+        "https://github.com/PrismLibrary/Prism"
+      ],
+      "allowedVersions": "<= 8.1.97",
+      "description": "Licensing changed from v9 and onward to be commercial. See https://github.com/PrismLibrary/Prism/releases/tag/9.0.264-pre for context."
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Description of changes
Disable package upgrades, for which licensing changed to commercial licenses:
* `FluentAssertions` in v8 and forward ([ref](https://fluentassertions.com/releases/#license-change))
* `Prism.*` packages in v9 and forward ([ref](https://github.com/PrismLibrary/Prism/releases/tag/9.0.264-pre))