### PR TITLE
Feature/sgd 18315

### DIFF
--- a/default.json
+++ b/default.json
@@ -93,28 +93,28 @@
         ":separateMajorReleases"
       ]
     },
-	{
-	  "groupName": "microsoft-dotnet",
-	  "matchManagers": ["nuget"],
-	  "matchPackageNames": ["/^Microsoft\\./i"],
-	  "matchSourceUrls": ["https://github.com/dotnet/*"],
-	  "extends": [
-		":separateMajorReleases"
-	  ],
-	  "description": "Microsoft.* packages published from the dotnet GitHub organization"
-	},
-	{
-	  "groupName": "microsoft-non-dotnet",
-	  "matchManagers": ["nuget"],
-	  "matchPackageNames": [
-		"/^Microsoft\\./i",
-		"/^System\\./i"
-	  ],
-	  "extends": [
-		":separateMajorReleases"
-	  ],
-	  "description": "Microsoft.* and System.* packages not from the dotnet GitHub organization"
-	},
+    {
+      "groupName": "microsoft-dotnet",
+      "matchPackageNames": [
+        "/^Microsoft\\./i",
+        "/^System\\./i"
+      ],
+      "extends": [
+        ":separateMajorReleases"
+      ]
+    },
+    {
+      "groupName": "microsoft-non-dotnet",
+	  "matchSourceUrls": ["!/^https:\/\/github.com\/dotnet\/"],
+      "matchPackageNames": [
+        "/^Microsoft\\./i",
+        "/^System\\./i"
+      ],
+      "extends": [
+        ":separateMajorReleases"
+      ],
+	  "description": "Microsoft.* and System.* packages not from dotnet (ie: Microsoft.Graph)"
+    },
     {
       "groupName": "workleap",
       "matchPackageNames": [

--- a/default.json
+++ b/default.json
@@ -93,16 +93,28 @@
         ":separateMajorReleases"
       ]
     },
-    {
-      "groupName": "microsoft",
-      "matchPackageNames": [
-        "/^Microsoft\\./i",
-        "/^System\\./i"
-      ],
-      "extends": [
-        ":separateMajorReleases"
-      ]
-    },
+	{
+	  "groupName": "microsoft-dotnet",
+	  "matchManagers": ["nuget"],
+	  "matchPackageNames": ["/^Microsoft\\./i"],
+	  "matchSourceUrls": ["https://github.com/dotnet/*"],
+	  "extends": [
+		":separateMajorReleases"
+	  ],
+	  "description": "Microsoft.* packages published from the dotnet GitHub organization"
+	},
+	{
+	  "groupName": "microsoft-non-dotnet",
+	  "matchManagers": ["nuget"],
+	  "matchPackageNames": [
+		"/^Microsoft\\./i",
+		"/^System\\./i"
+	  ],
+	  "extends": [
+		":separateMajorReleases"
+	  ],
+	  "description": "Microsoft.* and System.* packages not from the dotnet GitHub organization"
+	},
     {
       "groupName": "workleap",
       "matchPackageNames": [


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
The microsoft group is a bit too wide so packages like Microsoft.Graph or Microsoft.WebView2 are bundled with all the dotnet runtime packages. In SG migrate, the dotnet packages are often harder to bring back because of conflicts or breaking changes. That renovate PR is blocked with a bunch of packages that could be merged without the dotnet ones. This PR is to separate such packages into 2 PRs using negative string matching on the source url.

## Breaking changes
N/A

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [X] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes