### PR TITLE
Fix terraform config files

### DIFF
--- a/terraform-module.json
+++ b/terraform-module.json
@@ -11,12 +11,9 @@
   "packageRules": [
     {
       "matchDatasources": ["terraform-module"],
-      "matchPackageNames": ["Azure/naming/azurerm"],
-      "registryUrls": [
-        "https://registry.terraform.io"
-      ],
-      "groupName": "Azure/naming/azurerm upgrades",
-      "automerge": true,
+      "groupName": "Terraform module minor and patch upgrades",
+      "groupSlug": "terraform-module-minor-patch",
+      "matchUpdateTypes": ["minor", "patch"],
       "postUpgradeTasks": {
         "commands": [
           "terraform-docs markdown ./{{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
@@ -24,18 +21,6 @@
         "fileFilters": ["**/*.tf", "**/*.tfvars", "**/*.tftest"],
         "executionMode": "update"
       }
-    },
-    {
-      "matchDatasources": ["terraform-module"],
-      "matchPackageNames": ["terraform-workleap-enterprise-azure-governance"],
-      "groupName": "automerge specific terraform module",
-      "matchUpdateTypes": ["minor", "patch"], 
-      "automerge": true
-    },
-    {
-      "matchDatasources": ["terraform-module"],
-      "groupName": "Terraform module minor and patch upgrades",
-      "groupSlug": "terraform-module-minor-patch"
     }
   ]
 }

--- a/terraform-provider.json
+++ b/terraform-provider.json
@@ -1,22 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Upgrade all terraform providers with minor and patch upgrades",
-  "packageRules": [
-    {
-      "matchDatasources": ["terraform-provider"],
-      "groupName": "Terraform provider minor and patch upgrades",
-      "groupSlug": "terraform-provider-minor-patch",
-      "extends": [
-        ":automergePatch",
-        ":automergeMinor"
-      ]
-    }
-  ],
   "postUpgradeTasks": {
     "commands": [
       "terraform-docs markdown ./{{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
     ],
     "fileFilters": ["**/*.tf", "**/*.tfvars", "**/*.tftest"],
     "executionMode": "update"
-  }
+  },
+  "packageRules": [
+    {
+      "matchDatasources": ["terraform-provider"],
+      "groupName": "Terraform provider minor and patch upgrades",
+      "groupSlug": "terraform-provider-minor-patch"
+    }
+  ]
 }


### PR DESCRIPTION
Jira issue link: [FENG-457](https://workleap.atlassian.net/browse/FENG-457)

This pull request refactors the configuration for managing Terraform module and provider upgrades in `terraform-module.json` and `terraform-provider.json`. The changes streamline the structure, consolidate rules, and ensure consistent behavior for minor and patch upgrades.

### Refactoring Terraform module upgrade rules:

* Consolidated multiple rules for Terraform module upgrades into a single rule. This includes combining previously separate configurations for specific modules and general upgrades into one unified group named "Terraform module minor and patch upgrades" with a corresponding slug `terraform-module-minor-patch`.

### Refactoring Terraform provider upgrade rules:

* Reorganized the `terraform-provider.json` file to move `packageRules` below `postUpgradeTasks` for better readability and consistency. The rule for "Terraform provider minor and patch upgrades" remains unchanged in functionality but has been restructured for clarity.