### PR TITLE
Hotfix/feng 939

### DIFF
--- a/terraform-module.json
+++ b/terraform-module.json
@@ -14,10 +14,6 @@
       "groupName": "Terraform module minor and patch upgrades",
       "groupSlug": "terraform-module-minor-patch",
       "matchUpdateTypes": ["minor", "patch"],
-      "postUpgradeTasks": {
-        "commands": [
-          "terraform-docs markdown table --output-file README.md --hide resources,data-sources ./{{{ packageFileDir }}}"
-        ],
         "fileFilters": ["**/*.tf", "**/*.tfvars", "**/*.tftest"],
         "executionMode": "update"
       }

--- a/terraform-module.json
+++ b/terraform-module.json
@@ -3,7 +3,7 @@
   "description": "Upgrade all terraform modules with minor and patch upgrades",
   "postUpgradeTasks": {
     "commands": [
-      "terraform-docs markdown {{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
+      "terraform-docs markdown table --output-file README.md --hide resources,data-sources ./{{{ packageFileDir }}}"
     ],
     "fileFilters": ["**/*.tf", "**/*.tfvars", "**/*.tftest"],
     "executionMode": "update"
@@ -16,7 +16,7 @@
       "matchUpdateTypes": ["minor", "patch"],
       "postUpgradeTasks": {
         "commands": [
-          "terraform-docs markdown ./{{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
+          "terraform-docs markdown table --output-file README.md --hide resources,data-sources ./{{{ packageFileDir }}}"
         ],
         "fileFilters": ["**/*.tf", "**/*.tfvars", "**/*.tftest"],
         "executionMode": "update"

--- a/terraform-provider.json
+++ b/terraform-provider.json
@@ -3,7 +3,7 @@
   "description": "Upgrade all terraform providers with minor and patch upgrades",
   "postUpgradeTasks": {
     "commands": [
-      "terraform-docs markdown ./{{{ packageFileDir }}} --hide resources,data-sources --output-file README.md --output-mode replace"
+      "terraform-docs markdown table --output-file README.md --hide resources,data-sources ./{{{ packageFileDir }}}"
     ],
     "fileFilters": ["**/*.tf", "**/*.tfvars", "**/*.tftest"],
     "executionMode": "update"

--- a/terraform-provider.json
+++ b/terraform-provider.json
@@ -13,6 +13,16 @@
       "matchDatasources": ["terraform-provider"],
       "groupName": "Terraform provider minor and patch upgrades",
       "groupSlug": "terraform-provider-minor-patch"
+    },
+    {
+      "matchDatasources": ["terraform-provider"],
+      "matchPackageNames": ["cloudflare/cloudflare"],
+      "allowedVersions": "< 5"
+    },
+    {
+      "matchDatasources": ["terraform-provider"],
+      "matchPackageNames": ["zscaler/zpa"],
+      "allowedVersions": "< 4"
     }
   ]
 }


### PR DESCRIPTION
This pull request updates the configuration for Terraform module and provider upgrades, focusing on improving documentation generation and refining provider version constraints. The main changes are grouped into documentation improvements and provider version management.

**Documentation generation improvements:**

* Updated the `terraform-docs` command in both `terraform-module.json` and `terraform-provider.json` to use the `markdown table` format and changed the argument order to ensure consistent and clearer README output after upgrades. [[1]](diffhunk://#diff-5a5f7d49802be84552a469ab8748b94160c9007601b7b180f309d1efef16494dL6-R6) [[2]](diffhunk://#diff-ce07ca91c2f6d9a805d2807a539f29c9a83e12200c13000ab320f61319c50453L6-R6)
* Removed redundant `postUpgradeTasks` commands from the minor and patch upgrade group in `terraform-module.json` to streamline configuration.

**Provider version constraints:**

* Added specific allowed version constraints for `cloudflare/cloudflare` (versions less than 5) and `zscaler/zpa` (versions less than 4) in `terraform-provider.json` to prevent unintended major upgrades for these providers.